### PR TITLE
build: switch to nodenext + skipLibCheck

### DIFF
--- a/src/accessories/lock.ts
+++ b/src/accessories/lock.ts
@@ -1,7 +1,7 @@
 import { CharacteristicValue, Service } from 'homebridge';
 import { SmartRentPlatform } from '../platform.js';
 import type { SmartRentAccessory } from './index.js';
-import { LockData } from '../devices';
+import type { LockData } from '../devices/index.js';
 import { WSEvent } from '../lib/client.js';
 import { findStateByName } from '../lib/utils.js';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["ES2022"],
-    "module": "ES2022",
+    "module": "nodenext",
     "target": "ES2022",
     "declaration": true,
     "declarationMap": true,
@@ -13,7 +13,8 @@
     "noImplicitAny": false,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node"
+    "moduleResolution": "nodenext",
+    "skipLibCheck": true
   },
   "include": [".eslintrc.json", "homebridge-ui", "src/**/*.ts"],
   "exclude": ["**/*.spec.ts"]


### PR DESCRIPTION
## Summary
Mirror the same tsconfig hardening landed in `homebridge-philips-hue-sync-box` (#378, #379) preemptively, before homebridge 2.x's `@matter/*` transitive deps cause the same CI failure here.

## Changes
- `tsconfig.json`: `moduleResolution: "node"` → `"nodenext"`, `module: "ES2022"` → `"nodenext"`, add `skipLibCheck: true`.
- `src/accessories/lock.ts`: `import { LockData } from '../devices'` → `import type { LockData } from '../devices/index.js'`. `LockData` is only used in generic type parameters; classic `node` resolution silently allowed both the directory-implicit-index resolution and the missing `.js` because the import was erased at emit.

## Why
- Classic `moduleResolution: "node"` doesn't model Node's `package.json` `imports`/`exports`, so tsc and Node disagree about how to resolve deps. For an ESM project (`"type": "module"`) this mismatch is a footgun.
- `nodenext` matches Node's runtime behavior. `module: "nodenext"` is the conventional pairing. `skipLibCheck` defends against unrelated upstream `.d.ts` rot (it's not a substitute for `nodenext` — they fix different problems).

## Verification
- `npm run build` (clean → compile) passes.
- `npm run lint` passes.

## Test plan
- [ ] CI passes on this PR
- [ ] Smoke test the plugin against a real SmartRent hub + homebridge instance to confirm no runtime regression from `module: "nodenext"` (CJS/ESM interop semantics differ slightly from `module: "ES2022"`)