### PR TITLE
fix(dt-sbom): read DT CI key from renamed OpenBao path

### DIFF
--- a/.github/workflows/dt-sbom.yml
+++ b/.github/workflows/dt-sbom.yml
@@ -87,7 +87,7 @@ jobs:
           role: dt-sbom-upload
           jwtGithubAudience: openbao
           secrets: |
-            secret/data/dependency-track/ci-api-key apiKey | DT_API_KEY
+            secret/data/ci/dependency-track/ci-api-key apiKey | DT_API_KEY
 
       - name: Upload SBOM to Dependency-Track
         env:


### PR DESCRIPTION
The OpenBao path-audit rename moved the Dependency-Track CI key to `secret/ci/dependency-track/ci-api-key` and updated the `gha-dt-sbom-upload` policy to grant only that path, but `dt-sbom.yml` still requested the pre-rename `secret/data/dependency-track/ci-api-key`.

JWT login succeeds (claims match the allowlist), then the secret read is denied → `vault-action` returns **403 Forbidden** on every push to `main`. This aligns the path with the policy; `pr-license-comment.yml` and `homelab/dt-sbom-upload.yaml` were already migrated.

Verifiable only post-merge (the `upload` job runs on push-to-main, never on PRs).