### PR TITLE
docs: refresh README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@
 [![GitHub Last Commit](https://badgen.net/github/last-commit/jabrown93/homebridge-smartrent?color=cyan&icon=github)](https://github.com/jabrown93/homebridge-smartrent)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/jabrown93/homebridge-smartrent.svg)](https://github.com/jabrown93/homebridge-smartrent/pulls)
 [![GitHub issues](https://img.shields.io/github/issues/jabrown93/homebridge-smartrent.svg)](https://github.com/jabrown93/homebridge-smartrent/issues)
-[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B50603%2Fgithub.com%2Fjabrown93%2Fhomebridge-smartrent.svg?type=shield&issueType=license)](https://app.fossa.com/projects/custom%2B50603%2Fgithub.com%2Fjabrown93%2Fhomebridge-smartrent?ref=badge_shield&issueType=license)
-[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B50603%2Fgithub.com%2Fjabrown93%2Fhomebridge-smartrent.svg?type=shield&issueType=security)](https://app.fossa.com/projects/custom%2B50603%2Fgithub.com%2Fjabrown93%2Fhomebridge-smartrent?ref=badge_shield&issueType=security)
+[![Build](https://img.shields.io/github/actions/workflow/status/jabrown93/homebridge-smartrent/build.yml?label=build)](https://github.com/jabrown93/homebridge-smartrent/actions/workflows/build.yml)
+[![CodeQL](https://img.shields.io/github/actions/workflow/status/jabrown93/homebridge-smartrent/codeql.yml?label=CodeQL)](https://github.com/jabrown93/homebridge-smartrent/actions/workflows/codeql.yml)
+[![Release](https://img.shields.io/github/v/release/jabrown93/homebridge-smartrent)](https://github.com/jabrown93/homebridge-smartrent/releases)
 
 Unofficial [Homebridge](https://homebridge.io) plugin for [SmartRent](https://smartrent.com), allowing you to control your SmartRent devices with [Apple Home](https://www.apple.com/ios/home/).
 
@@ -165,8 +166,6 @@ Please checkout our [Code of Conduct](./CODE_OF_CONDUCT.md) for more information
 ## License
 
 [GNU GENERAL PUBLIC LICENSE, Version 3](https://www.gnu.org/licenses/gpl-3.0.en.html)
-
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fjabrown93%2Fhomebridge-smartrent.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fjabrown93%2Fhomebridge-smartrent?ref=badge_large)
 
 ## Disclaimer
 


### PR DESCRIPTION
## Summary
- Adds build status, CodeQL status, and latest-release badges.
- Removes the three FOSSA badges — `fossa.yml` was replaced by the internal Dependency-Track SBOM workflow, so those FOSSA project pages are no longer updated and the badges were stale.

## Test plan
- [ ] Preview README on GitHub to confirm badges render