### PR TITLE
fix(security): stop logging credentials/tokens, lock down session file

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -16,11 +16,13 @@
       "password": {
         "title": "Password",
         "type": "string",
+        "format": "password",
         "required": true
       },
       "tfaSecret": {
         "title": "Two-factor authentication code",
         "type": "string",
+        "format": "password",
         "required": false,
         "pattern": "^[A-Z0-9]{32}$",
         "minLength": 32,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -102,8 +102,6 @@ export class SmartRentApi {
     const devices = await this.client.get<Array<DeviceDataUnion>>(
       `/hubs/${hubId}/devices`
     );
-    this.platform.log.info('Devices Found: ', devices);
-
     if (devices.length) {
       this.platform.log.info(`Found ${devices.length} devices`);
     } else {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -17,6 +17,7 @@ import {
 } from './request.js';
 import { jwtDecode } from 'jwt-decode';
 import { generateSync } from 'otplib';
+import { redactSensitive } from './utils.js';
 
 const USER_PREFIX = 'User:';
 /** Credentials stored in config.json */
@@ -120,12 +121,18 @@ export class SmartRentAuthClient {
    * @returns SmartRent response data payload
    */
   private _handleResponse(response: AxiosResponse) {
-    this.log.debug('Response:', JSON.stringify(response.data, null, 2));
+    this.log.debug(
+      'Response:',
+      JSON.stringify(redactSensitive(response.data), null, 2)
+    );
     return response;
   }
 
   private _handleRequest(config: InternalAxiosRequestConfig) {
-    this.log.debug('Request:', JSON.stringify(config, null, 2));
+    this.log.debug(
+      'Request:',
+      JSON.stringify(redactSensitive(config), null, 2)
+    );
     return config;
   }
 
@@ -190,9 +197,7 @@ export class SmartRentAuthClient {
     };
 
     this.log.info(`${refreshed ? 'Refreshed' : 'Started'} SmartRent session`);
-    const sessionStr = JSON.stringify(this.session, null, 2);
-    await fsPromises.writeFile(this.sessionPath, sessionStr);
-    this.log.debug('Saved session to', this.sessionPath);
+    await this._writeSessionFile();
     return this.session;
   }
 
@@ -204,10 +209,19 @@ export class SmartRentAuthClient {
       webSocketToken: data,
       websocketExpires: SmartRentAuthClient._getExpireDate(exp),
     };
-    const sessionStr = JSON.stringify(this.session, null, 2);
-    await fsPromises.writeFile(this.sessionPath, sessionStr);
-    this.log.debug('Saved session to', this.sessionPath);
+    await this._writeSessionFile();
     return this.session;
+  }
+
+  /**
+   * Persist the current session to disk with owner-only permissions, since it
+   * contains a live SmartRent access token.
+   */
+  private async _writeSessionFile() {
+    const sessionStr = JSON.stringify(this.session, null, 2);
+    await fsPromises.writeFile(this.sessionPath, sessionStr, { mode: 0o600 });
+    await fsPromises.chmod(this.sessionPath, 0o600);
+    this.log.debug('Saved session to', this.sessionPath);
   }
 
   /**
@@ -242,7 +256,7 @@ export class SmartRentAuthClient {
       return this._storeSession(sessionData);
     }
 
-    this.log.debug('Session data:', sessionData);
+    this.log.debug('Session data:', redactSensitive(sessionData));
     // If 2FA is enabled, start a 2FA session
     if (SmartRentAuthClient._isTfaSession(sessionData)) {
       this.log.debug('2FA enabled');

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -168,6 +168,9 @@ export class SmartRentAuthClient {
           'utf8'
         );
         this.session = JSON.parse(sessionString) as Session;
+        // Lock down session files left over from before owner-only
+        // permissions were enforced on write.
+        await this._chmodSessionFile();
       } catch (err) {
         this.log.error('Error reading saved session', err);
         await fsPromises.rm(this.sessionPath);
@@ -175,6 +178,19 @@ export class SmartRentAuthClient {
       }
     } else if (!existsSync(this.pluginPath)) {
       await fsPromises.mkdir(this.pluginPath);
+    }
+  }
+
+  /**
+   * Best-effort restriction of the session file to owner-only permissions.
+   * Not fatal: some platforms/filesystems (e.g. Windows, some network
+   * filesystems) don't support POSIX permission bits.
+   */
+  private async _chmodSessionFile() {
+    try {
+      await fsPromises.chmod(this.sessionPath, 0o600);
+    } catch (err) {
+      this.log.debug('Could not restrict session file permissions', err);
     }
   }
 
@@ -220,7 +236,7 @@ export class SmartRentAuthClient {
   private async _writeSessionFile() {
     const sessionStr = JSON.stringify(this.session, null, 2);
     await fsPromises.writeFile(this.sessionPath, sessionStr, { mode: 0o600 });
-    await fsPromises.chmod(this.sessionPath, 0o600);
+    await this._chmodSessionFile();
     this.log.debug('Saved session to', this.sessionPath);
   }
 

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -14,6 +14,7 @@ import { SmartRentAuthClient } from './auth.js';
 import { SmartRentPlatform } from '../platform.js';
 import WebSocket from 'ws';
 import { Logger } from 'homebridge';
+import { redactSensitive } from './utils.js';
 
 export type WSDeviceList = `devices:${string}`;
 export type WSEvent = {
@@ -99,7 +100,10 @@ export class SmartRentApiClient {
       ...config.headers,
       Authorization: `Bearer ${accessToken}`,
     } as AxiosRequestHeaders;
-    this.log.debug('Request:', JSON.stringify(config, null, 2));
+    this.log.debug(
+      'Request:',
+      JSON.stringify(redactSensitive(config), null, 2)
+    );
     return config;
   }
 
@@ -109,7 +113,10 @@ export class SmartRentApiClient {
    * @returns SmartRent response data payload
    */
   private _handleResponse(response: AxiosResponse) {
-    this.log.debug('Response:', JSON.stringify(response.data, null, 2));
+    this.log.debug(
+      'Response:',
+      JSON.stringify(redactSensitive(response.data), null, 2)
+    );
     return response;
   }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,3 +6,33 @@ export function findStateByName(
 ): string | number | boolean | null {
   return objects.find(obj => obj.name === name)?.state ?? null;
 }
+
+const SENSITIVE_KEYS = new Set([
+  'password',
+  'token',
+  'tfa_api_token',
+  'access_token',
+  'accesstoken',
+  'websockettoken',
+  'authorization',
+]);
+
+/**
+ * Recursively redacts values of known-sensitive keys (passwords, tokens, auth headers)
+ * so request/response payloads can be safely logged at debug level.
+ */
+export function redactSensitive<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map(redactSensitive) as unknown as T;
+  }
+  if (value && typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      result[key] = SENSITIVE_KEYS.has(key.toLowerCase())
+        ? '[REDACTED]'
+        : redactSensitive(val);
+    }
+    return result as T;
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary
- Debug-level request/response logging in `auth.ts` and `client.ts` was serializing the full axios request config and response body, leaking plaintext passwords, TFA codes, and OAuth/websocket bearer tokens into `homebridge.log` whenever debug logging is enabled (the default for `npm run watch`, and a common troubleshooting step users paste into GitHub issues).
- Added `redactSensitive()` (`src/lib/utils.ts`) to mask known-sensitive keys before logging, applied to all four debug-log call sites in `auth.ts`/`client.ts`.
- `session.json` (holds the live access token) is now written with `0600` permissions instead of inheriting the process umask.
- `config.schema.json`: `password`/`tfaSecret` now use `"format": "password"` so homebridge-config-ui-x masks them in the settings form instead of showing plaintext.

## Test plan
- [x] `npm run tsc` — passes
- [x] `npm run lint` — passes
- [x] `npm run build` — passes
- [ ] Manual: run `npm run watch` against a real SmartRent account with debug logging on and confirm `test/hbConfig/homebridge.log` no longer contains the password, TFA token, or bearer tokens

https://claude.ai/code/session_015ZGARtxqQDH2KgqFnAGrho