### PR TITLE
feat: add motion sensor support and fix dimmer/thermostat state bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Homebridge SmartRent currently supports these devices through a SmartRent hub:
 
 - 🔒 Locks
 - 💧 Leak sensors
+- 🏃 Motion sensors
 - 🔌 Switches
 - 🌡 Thermostats
 - 🎚 Multilevel (Dimmer) Switches

--- a/config.schema.json
+++ b/config.schema.json
@@ -36,6 +36,13 @@
         "default": true,
         "description": "Uncheck to disable leak sensors."
       },
+      "enableMotionSensors": {
+        "title": "Enable motion sensors",
+        "type": "boolean",
+        "required": false,
+        "default": true,
+        "description": "Uncheck to disable motion sensors."
+      },
       "enableThermostats": {
         "title": "Enable thermostats",
         "type": "boolean",

--- a/src/accessories/index.ts
+++ b/src/accessories/index.ts
@@ -3,6 +3,7 @@ import { DeviceDataUnion } from '../devices/index.js';
 
 export * from './leakSensor.js';
 export * from './lock.js';
+export * from './motionSensor.js';
 export * from './switch.js';
 export * from './thermostat.js';
 export * from './switchMultilevel.js';

--- a/src/accessories/motionSensor.ts
+++ b/src/accessories/motionSensor.ts
@@ -1,0 +1,97 @@
+import { CharacteristicValue, Service } from 'homebridge';
+import { SmartRentPlatform } from '../platform.js';
+import type { SmartRentAccessory } from './index.js';
+import { WSEvent } from '../lib/client.js';
+import { findStateByName } from '../lib/utils.js';
+
+/**
+ * Motion Sensor Accessory
+ * An instance of this class is created for each accessory the platform registers
+ * Each accessory may expose multiple services of different service types.
+ */
+export class MotionSensorAccessory {
+  private readonly service: Service;
+
+  private readonly state: {
+    hubId: string;
+    deviceId: string;
+    motion: {
+      current: CharacteristicValue;
+    };
+  };
+
+  constructor(
+    private readonly platform: SmartRentPlatform,
+    private readonly accessory: SmartRentAccessory
+  ) {
+    this.state = {
+      hubId: this.accessory.context.device.room.hub_id.toString(),
+      deviceId: this.accessory.context.device.id.toString(),
+      motion: {
+        current: false,
+      },
+    };
+
+    // set accessory information
+    this.accessory
+      .getService(this.platform.api.hap.Service.AccessoryInformation)!
+      .setCharacteristic(
+        this.platform.api.hap.Characteristic.SerialNumber,
+        this.accessory.context.device.id.toString()
+      );
+
+    // get the MotionSensor service if it exists, otherwise create a new MotionSensor service
+    this.service =
+      this.accessory.getService(this.platform.api.hap.Service.MotionSensor) ||
+      this.accessory.addService(this.platform.api.hap.Service.MotionSensor);
+
+    // set the service name, this is what is displayed as the default name on the Home app
+    this.service.setCharacteristic(
+      this.platform.api.hap.Characteristic.Name,
+      accessory.context.device.name
+    );
+
+    // create handlers for required characteristics
+    // see https://developers.homebridge.io/#/service/MotionSensor
+    this.service
+      .getCharacteristic(this.platform.api.hap.Characteristic.MotionDetected)
+      .onGet(this.handleMotionDetectedGet.bind(this));
+
+    // subscribe to device events
+    this.platform.smartRentApi.websocket.event[this.state.deviceId] = (
+      event: WSEvent
+    ) => this.handleDeviceStateChanged(event);
+  }
+
+  /**
+   * Handle requests to get the current value of the "Motion Detected" characteristic
+   */
+  async handleMotionDetectedGet(): Promise<CharacteristicValue> {
+    this.platform.log.debug('Triggered GET MotionDetected');
+    const motionAttributes = await this.platform.smartRentApi.getState(
+      this.state.hubId,
+      this.state.deviceId
+    );
+    const motion = Boolean(findStateByName(motionAttributes, 'motion_binary'));
+    this.state.motion.current = motion;
+    return motion;
+  }
+
+  /**
+   * Handle device state changed events
+   * @param event
+   */
+  handleDeviceStateChanged(event: WSEvent) {
+    this.platform.log.debug('Received websocket motion event:', event);
+
+    if (event.name !== 'motion_binary') {
+      return;
+    }
+    const motion = event.last_read_state === 'true';
+    this.state.motion.current = motion;
+    this.service.updateCharacteristic(
+      this.platform.api.hap.Characteristic.MotionDetected,
+      motion
+    );
+  }
+}

--- a/src/accessories/switchMultilevel.ts
+++ b/src/accessories/switchMultilevel.ts
@@ -88,16 +88,29 @@ export class SwitchMultilevelAccessory {
       'Received websocket Switch Multilevel event:',
       event
     );
-    if (event.name !== 'on') {
-      return;
+    switch (event.name) {
+      case 'level': {
+        const level = Number(event.last_read_state);
+        this.state.brightness.current = level;
+        this.state.on.current = level > 0 ? 1 : 0;
+        this.service.updateCharacteristic(
+          this.platform.api.hap.Characteristic.Brightness,
+          level
+        );
+        this.service.updateCharacteristic(
+          this.platform.api.hap.Characteristic.On,
+          this.state.on.current
+        );
+        break;
+      }
+      case 'on':
+        this.state.on.current = event.last_read_state === 'true' ? 1 : 0;
+        this.service.updateCharacteristic(
+          this.platform.api.hap.Characteristic.On,
+          this.state.on.current
+        );
+        break;
     }
-
-    this.state.on.current = 0;
-
-    this.service.updateCharacteristic(
-      this.platform.api.hap.Characteristic.On,
-      this.state.on.current
-    );
   }
 
   /**
@@ -114,9 +127,11 @@ export class SwitchMultilevelAccessory {
       switchMultilevelAttributes,
       'level'
     ) as number;
-    const level = Number(levelAttribute) > 0 ? 1 : 0;
-    this.state.on.current = level;
-    return level;
+    const brightness = Number(levelAttribute);
+    const on = brightness > 0 ? 1 : 0;
+    this.state.brightness.current = brightness;
+    this.state.on.current = on;
+    return on;
   }
 
   /**
@@ -137,7 +152,13 @@ export class SwitchMultilevelAccessory {
       'level'
     ) as number;
 
-    this.state.on.current = Number(levelAttribute) > 0 ? 1 : 0;
+    const level = Number(levelAttribute);
+    this.state.on.current = level > 0 ? 1 : 0;
+    this.state.brightness.current = level;
+    this.service.updateCharacteristic(
+      this.platform.api.hap.Characteristic.Brightness,
+      level
+    );
   }
 
   /**
@@ -154,16 +175,17 @@ export class SwitchMultilevelAccessory {
       switchMultilevelAttributes,
       'level'
     ) as number;
-    this.state.on.current = level;
+    this.state.brightness.current = level;
+    this.state.on.current = Number(level) > 0 ? 1 : 0;
     return level;
   }
 
   /**
-   * Handle requests to set the "On" characteristic
+   * Handle requests to set the "Brightness" characteristic
    */
   async handleBrightnessSet(value: CharacteristicValue) {
     this.platform.log.debug('Triggered SET Brightness:', value);
-    this.state.on.target = value;
+    this.state.brightness.target = value;
     const newAttributes = [{ name: 'level', state: Number(value) }];
     const switchMultilevelAttributes =
       await this.platform.smartRentApi.setState<SwitchMultilevelData>(
@@ -171,9 +193,15 @@ export class SwitchMultilevelAccessory {
         this.state.deviceId,
         newAttributes
       );
-    this.state.on.current = findStateByName(
+    const level = findStateByName(
       switchMultilevelAttributes,
       'level'
     ) as number;
+    this.state.brightness.current = level;
+    this.state.on.current = Number(level) > 0 ? 1 : 0;
+    this.service.updateCharacteristic(
+      this.platform.api.hap.Characteristic.On,
+      this.state.on.current
+    );
   }
 }

--- a/src/accessories/thermostat.ts
+++ b/src/accessories/thermostat.ts
@@ -6,6 +6,7 @@ import {
   ThermostatData,
   ThermostatFanMode,
   ThermostatMode,
+  ThermostatOperatingState,
 } from '../devices/index.js';
 import { WSEvent } from '../lib/client.js';
 import { findStateByName } from '../lib/utils.js';
@@ -198,6 +199,9 @@ export class ThermostatAccessory {
       case 'mode':
         this.handleModeChange(event);
         break;
+      case 'operating_state':
+        this.handleOperatingStateChange(event);
+        break;
       case 'cooling_setpoint':
         this.handleCoolingSetpointChange(event);
         break;
@@ -296,6 +300,17 @@ export class ThermostatAccessory {
     );
   }
 
+  private handleOperatingStateChange(event: WSEvent) {
+    const operatingState = this.toCurrentHeatingCoolingStateFromOperatingState(
+      event.last_read_state as ThermostatOperatingState
+    );
+    this.state.heating_cooling_state.current = operatingState;
+    this.thermostatService.updateCharacteristic(
+      this.platform.api.hap.Characteristic.CurrentHeatingCoolingState,
+      operatingState
+    );
+  }
+
   private handleFanModeChange(event: WSEvent) {
     const fanMode = this.toFanOnCharacteristic(
       event.last_read_state as ThermostatFanMode
@@ -317,6 +332,25 @@ export class ThermostatAccessory {
       case 'heat':
         return this.platform.api.hap.Characteristic.CurrentHeatingCoolingState
           .HEAT;
+      case 'off':
+      default:
+        return this.platform.api.hap.Characteristic.CurrentHeatingCoolingState
+          .OFF;
+    }
+  }
+
+  private toCurrentHeatingCoolingStateFromOperatingState(
+    operatingState?: ThermostatOperatingState | string | null
+  ) {
+    switch (operatingState) {
+      case 'cooling':
+        return this.platform.api.hap.Characteristic.CurrentHeatingCoolingState
+          .COOL;
+      case 'heating':
+        return this.platform.api.hap.Characteristic.CurrentHeatingCoolingState
+          .HEAT;
+      case 'fan_only':
+      case 'idle':
       case 'off':
       default:
         return this.platform.api.hap.Characteristic.CurrentHeatingCoolingState
@@ -390,7 +424,7 @@ export class ThermostatAccessory {
     temperature: number
   ): DeviceAttribute[] {
     const target_temp = this.fromTemperatureCharacteristic(temperature);
-    switch (this.state.heating_cooling_state.current) {
+    switch (this.state.heating_cooling_state.target) {
       case this.platform.api.hap.Characteristic.TargetHeatingCoolingState.OFF:
       case this.platform.api.hap.Characteristic.TargetHeatingCoolingState.COOL:
         return [{ name: 'cool_target_temp', state: target_temp }];
@@ -447,9 +481,16 @@ export class ThermostatAccessory {
       this.state.deviceId
     );
 
-    const currentValue = this.toCurrentHeatingCoolingStateCharacteristic(
-      findStateByName(thermostatAttributes, 'mode') as ThermostatMode
-    );
+    const operatingState = findStateByName(
+      thermostatAttributes,
+      'operating_state'
+    ) as ThermostatOperatingState | null;
+    const currentValue =
+      operatingState !== null
+        ? this.toCurrentHeatingCoolingStateFromOperatingState(operatingState)
+        : this.toCurrentHeatingCoolingStateCharacteristic(
+            findStateByName(thermostatAttributes, 'mode') as ThermostatMode
+        );
     this.state.heating_cooling_state.current = currentValue;
     return currentValue;
   }
@@ -468,7 +509,7 @@ export class ThermostatAccessory {
     const currentValue = this.toTargetHeatingCoolingStateCharacteristic(
       findStateByName(thermostatAttributes, 'mode') as ThermostatMode
     );
-    this.state.heating_cooling_state.current = currentValue;
+    this.state.heating_cooling_state.target = currentValue;
     return currentValue;
   }
 
@@ -486,7 +527,7 @@ export class ThermostatAccessory {
         this.state.deviceId,
         newAttributes
       );
-    this.state.heating_cooling_state.current =
+    this.state.heating_cooling_state.target =
       this.toTargetHeatingCoolingStateCharacteristic(
         findStateByName(thermostatAttributes, 'mode') as ThermostatMode
       );
@@ -622,7 +663,7 @@ export class ThermostatAccessory {
         newAttributes
       );
 
-    this.state.heating_threshold_temperature.current =
+    this.state.cooling_threshold_temperature.current =
       this.toTemperatureCharacteristic(
         findStateByName(thermostatAttributes, 'cool_target_temp') as number
       );

--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -1,5 +1,6 @@
 import { LeakSensorData } from './leakSensor.js';
 import { LockData } from './lock.js';
+import { MotionSensorData } from './motionSensor.js';
 import { SwitchData } from './switch.js';
 import { SwitchMultilevelData } from './switchMultilevel.js';
 import { ThermostatData } from './thermostat.js';
@@ -7,6 +8,7 @@ import { ThermostatData } from './thermostat.js';
 export * from './base.js';
 export * from './leakSensor.js';
 export * from './lock.js';
+export * from './motionSensor.js';
 export * from './switch.js';
 export * from './thermostat.js';
 export * from './switchMultilevel.js';
@@ -14,6 +16,7 @@ export * from './switchMultilevel.js';
 export type DeviceDataUnion =
   | LeakSensorData
   | LockData
+  | MotionSensorData
   | SwitchData
   | ThermostatData
   | SwitchMultilevelData;

--- a/src/devices/motionSensor.ts
+++ b/src/devices/motionSensor.ts
@@ -1,0 +1,3 @@
+import { DeviceData } from './base.js';
+
+export type MotionSensorData = DeviceData<'sensor_notification', true>;

--- a/src/devices/thermostat.ts
+++ b/src/devices/thermostat.ts
@@ -2,5 +2,7 @@ import { DeviceData } from './base.js';
 
 export type ThermostatFanMode = 'auto' | 'on';
 export type ThermostatMode = 'off' | 'cool' | 'heat' | 'auto';
+export type ThermostatOperatingState =
+  'cooling' | 'fan_only' | 'heating' | 'idle' | 'off';
 
 export type ThermostatData = DeviceData<'thermostat', false>;

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -21,13 +21,16 @@ export type WSEvent = {
   id: number;
   name:
     | 'leak'
+    | 'motion_binary'
     | 'fan_mode'
     | 'current_temp'
     | 'current_humidity'
     | 'heating_setpoint'
     | 'cooling_setpoint'
     | 'mode'
+    | 'operating_state'
     | 'locked'
+    | 'level'
     | 'on'
     | 'notifications';
   remote_id: string;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -7,6 +7,7 @@ export interface SmartRentPlatformConfig extends PlatformConfig {
   password: string;
   tfaSecret?: string;
   enableLeakSensors?: boolean;
+  enableMotionSensors?: boolean;
   enableLocks?: boolean;
   enableSwitches?: boolean;
   enableThermostats?: boolean;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -5,6 +5,7 @@ import {
   SmartRentAccessory,
   LockAccessory,
   LeakSensorAccessory,
+  MotionSensorAccessory,
   SwitchAccessory,
   ThermostatAccessory,
   SwitchMultilevelAccessory,
@@ -62,6 +63,7 @@ export class SmartRentPlatform implements DynamicPlatformPlugin {
     let Accessory:
       | typeof LeakSensorAccessory
       | typeof LockAccessory
+      | typeof MotionSensorAccessory
       | typeof SwitchAccessory
       | typeof ThermostatAccessory
       | typeof SwitchMultilevelAccessory;
@@ -80,6 +82,12 @@ export class SmartRentPlatform implements DynamicPlatformPlugin {
       this.config.enableLeakSensors
     ) {
       Accessory = LeakSensorAccessory;
+    } else if (
+      type === 'sensor_notification' &&
+      attributeNames.includes('motion_binary') &&
+      this.config.enableMotionSensors
+    ) {
+      Accessory = MotionSensorAccessory;
     } else if (type === 'entry_control' && this.config.enableLocks) {
       Accessory = LockAccessory;
     } else if (type === 'switch_binary' && this.config.enableSwitches) {


### PR DESCRIPTION
## Summary

Ports the one substantive commit from upstream (`bhavishyachandra/homebridge-smartrent#83`) that this fork was missing, adapted to this fork's diverged device model (attribute arrays + `findStateByName`, `ALLOWED_DEVICE_TYPES`/`enable*` config-flag gating) since a direct cherry-pick conflicted in 6 files.

- **New:** motion sensor support (`sensor_notification` devices with a `motion_binary` attribute) behind a new `enableMotionSensors` config flag (default `true`), mirroring the existing leak sensor accessory.
- **Fix (switch_multilevel/dimmer):** the websocket `'on'` event handler hardcoded state to `0` regardless of the actual event payload; brightness and on-state were never synced with each other across get/set/websocket paths (e.g. `handleBrightnessGet`/`Set` were writing into `state.on` instead of `state.brightness`).
- **Fix (thermostat):** several handlers wrote `heating_cooling_state.current` where `.target` was intended, which fed a stale mode into `fromTargetTemperatureCharacteristic`'s choice of cool vs. heat setpoint when setting target temperature. Also fixes a copy-paste bug where setting the cooling threshold updated `heating_threshold_temperature` instead of `cooling_threshold_temperature`. `CurrentHeatingCoolingState` now prefers the device's reported `operating_state` (cooling/heating/idle/etc.) over the mode-based heuristic when present.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint .` — clean
- [ ] `npm run watch` against a real SmartRent account to confirm motion sensor discovery, dimmer brightness sync, and thermostat state reporting in HomeKit (no test suite exists per AGENTS.md; this repo has no CI-run tests)

https://claude.ai/code/session_01EW5gA43QPiaua3cTDkRJqC