### PR TITLE
ci(release): build in prepack instead of gating publish on checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "compile": "tsc",
     "build": "npm-run-all clean compile",
     "watch": "npm run dev-setup && npm run build && npm link && nodemon",
-    "prepublishOnly": "npm-run-all prettier lint build",
     "semantic-release": "cross-env semantic-release --no-ci",
     "release": "npm-run-all build semantic-release",
     "test": "echo \"Error: no test specified\" && exit 0",
@@ -50,7 +49,8 @@
     "tsc": "tsc --noEmit",
     "dev-setup": "npm run setup-config && npm run setup-log",
     "setup-config": "if [ ! -f ./test/hbConfig/config.json ]; then cp ./test/hbConfig/config-template.json ./test/hbConfig/config.json; fi",
-    "setup-log": "touch $(pwd)/test/hbConfig/homebridge.log && sed -i '' \"s|<log_file>|$(pwd)/test/hbConfig/homebridge.log|g\" $(pwd)/test/hbConfig/config.json"
+    "setup-log": "touch $(pwd)/test/hbConfig/homebridge.log && sed -i '' \"s|<log_file>|$(pwd)/test/hbConfig/homebridge.log|g\" $(pwd)/test/hbConfig/config.json",
+    "prepack": "npm-run-all clean compile"
   },
   "dependencies": {
     "@homebridge/plugin-ui-utils": "^2.0.0",


### PR DESCRIPTION
## Problem

`prepublishOnly` runs `prettier`, `lint` and `build` **inside `npm publish`**. That puts the quality gate in the worst possible place.

By the time `npm publish` runs, the release is already public:

1. `@semantic-release/git` commits the release and **pushes** — during `prepare`
2. semantic-release creates and **pushes the tag** — before the publish plugins run
3. *then* `npm publish` runs `prepublishOnly`

So anything `prepublishOnly` rejects fails **after** the tag, CHANGELOG entry and version bump have already landed — and npm never gets the package. A formatting nit half-releases the repo.

This is not hypothetical. `homebridge-philips-hue-sync-box` has **no 3.x on npm at all** (`latest` is `2.3.0`) while `3.0.0`–`3.0.5` are all tagged and changelogged. One `prettier` warning on a generated `sbom.cdx.json` did that.

## Fix

Move the build to **`prepack`** — the hook that actually needs to run. npm fires it for both code paths semantic-release uses:

| semantic-release step | npm command | hooks fired |
|---|---|---|
| `prepare` (tarballDir) | `npm pack` | `prepack` |
| `publish` | `npm publish` | `prepublishOnly` → `prepack` |

Publishing now only produces the artifact and cannot fail on style.

```diff
-  "prepublishOnly": "npm-run-all prettier lint build",
+  "prepack": "npm-run-all clean compile",
```

## The checks are not dropped

- `lint` and `build` already run in CI (`node-build.yml`).
- `prettier` did **not** — CI ran lint and build but never prettier. Added in jabrown93/.github#24. That must merge and be tagged, then this repo re-pins the workflow SHA.

The pre-commit hook alone isn't enough: it's bypassable with `--no-verify` and doesn't cover Renovate or web-UI commits — which is how an unformatted `pr-license-comment.yml` reached `main` in four repos at once.

## Verification

With `dist/` deleted and a deliberate prettier violation present, `npm pack` still builds `dist` and packs the `main` entry (`dist/index.js`) — exit 0, prettier never runs.