### PR TITLE
ci: migrate shared CI to jabrown93/ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,14 @@ on:
   - pull_request
 jobs:
   build:
-    uses: jabrown93/.github/.github/workflows/node-build.yml@644b89511f2e5143fb600246050eaf3aa5f532eb # v1.5.0
-    with:
-      node-versions: '["22.x", "24.x"]'
+    # node-build is now a composite action, so the caller owns the matrix and
+    # runs-on (a composite action cannot declare either).
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['22.x', '24.x']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jabrown93/ci/actions/node-build@63fdb1321ea7e94b330b23d87a9c9961ed6b86b5 # node-build-v1.0.0
+        with:
+          node-version: ${{ matrix.node-version }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,9 +9,14 @@ on:
     - cron: '25 22 * * 5'
 jobs:
   analyze:
-    uses: jabrown93/.github/.github/workflows/codeql.yml@644b89511f2e5143fb600246050eaf3aa5f532eb # v1.5.0
+    # codeql is now a composite action, so the caller owns runs-on and MUST
+    # grant the permissions CodeQL needs. Language defaults to
+    # javascript-typescript / build-mode none, which is correct for this repo.
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
       packages: read
       actions: read
       contents: read
+    steps:
+      - uses: jabrown93/ci/actions/codeql@63fdb1321ea7e94b330b23d87a9c9961ed6b86b5 # codeql-v1.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: false
 jobs:
   release:
-    uses: jabrown93/.github/.github/workflows/npm-release.yml@644b89511f2e5143fb600246050eaf3aa5f532eb # v1.5.0
+    uses: jabrown93/ci/.github/workflows/npm-release.yml@63fdb1321ea7e94b330b23d87a9c9961ed6b86b5 # workflows-v1.0.0
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -5,8 +5,12 @@ on:
     - cron: '30 1 * * *'
 jobs:
   stale:
-    uses: jabrown93/.github/.github/workflows/stale.yml@644b89511f2e5143fb600246050eaf3aa5f532eb # v1.5.0
+    # stale is now a composite action, so the caller owns runs-on and MUST grant
+    # the permissions actions/stale needs. The schedule trigger stays here.
+    runs-on: ubuntu-latest
     permissions:
       actions: write
       issues: write
       pull-requests: write
+    steps:
+      - uses: jabrown93/ci/actions/stale@63fdb1321ea7e94b330b23d87a9c9961ed6b86b5 # stale-v1.0.0


### PR DESCRIPTION
## Migrate shared CI to `jabrown93/ci`

Repoints this repo off the reusable workflows in `jabrown93/.github` onto the versioned CI library `jabrown93/ci`. Part of the CI split; mirrors the validated `homebridge-philips-hue-sync-box#446`.

`node-build`, `codeql`, and `stale` are now **composite actions**, so their caller jobs own `runs-on`, the matrix, and the schedule. `npm-release` stays a **job-level reusable workflow**.

| File | Before | After |
|---|---|---|
| build | `node-build.yml` reusable | `actions/node-build`, matrix `['22.x','24.x']` owned here (`fail-fast:false`) |
| codeql | `codeql.yml` reusable | `actions/codeql` (javascript-typescript default; same job permissions) |
| stale | `stale.yml` reusable | `actions/stale` (schedule + permissions on the caller job) |
| release | `npm-release.yml@…#v1.5.0` | `npm-release.yml@63fdb13 # workflows-v1.0.0` (byte-identical file) |

### ⚠️ Behavior change to review
The `node-build` action runs **`npm run test`** — which the old reusable workflow did **not**. (This repo was on v1.5.0, which already ran `prettier`; only `test` is newly added.) If `test`/`prettier` fail on this repo, that's a pre-existing gap the migration surfaces; the Build check on this PR is the gate.

All refs pinned to `jabrown93/ci@63fdb13`. `ci:` commit → no release bump. `dt-sbom.yml` is hand-inlined (not a consumer of the moved workflow) — untouched.
